### PR TITLE
Clarify person and memory scope in long reflection

### DIFF
--- a/GenAI-NLP/ShortProject-TradingAgent/Agent-Trading-Arena/Agent-Trading-Arena/Stock_Main/content/our_run_gpt_prompt.py
+++ b/GenAI-NLP/ShortProject-TradingAgent/Agent-Trading-Arena/Agent-Trading-Arena/Stock_Main/content/our_run_gpt_prompt.py
@@ -226,7 +226,14 @@ def integrate_long_reflect_info(virtual_date, persona:Person):
         virtual_date-=1
         iteration+=1
         memory = persona.query_memory(virtual_date)
-        p = persona.query_person(virtual_date)
+        person_state = persona.query_person(virtual_date)
+        # persona.query_person returns a list of dicts, but it only ever contains a
+        # single record per (person, virtual_date). Grab that record (if present)
+        # so we can safely reference the cash/wealth fields below.
+        # persona.query_memory returns a list of dicts as well, but every entry is
+        # already scoped to the same person, so we reuse the single person record
+        # for all memory rows on that date.
+        p = person_state[0] if person_state else {}
         #pre_reflect_info = ""
         for m in memory:
             if m["Iteration"]==2:


### PR DESCRIPTION
## Summary
- clarify that query_person returns a single record per date and reuse it for all memory entries
- note that query_memory already scopes results to the same person and date

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2f8492bc8320a4ae7f6ec5de0b79)